### PR TITLE
Wrong variant image color in the cart

### DIFF
--- a/src/CommerceModel.BetterRetail.Activities/SetAdditionnalLineItemAttributesActivity.cs
+++ b/src/CommerceModel.BetterRetail.Activities/SetAdditionnalLineItemAttributesActivity.cs
@@ -96,23 +96,9 @@ namespace CommerceModel.BetterRetail.Activities
                 var product = products.SingleOrDefault(p => p.Id.Equals(lineItem.ProductId, StringComparison.InvariantCultureIgnoreCase));
 
                 var allowSelectionWithoutScan = product?.PropertyBag?.GetOrDefault<bool>(AllowSelectionWithoutScanKey, false) ?? false;
-                var imageUrl = product?.PropertyBag?.GetOrDefault<string>(ImageUrlKey, null);
 
                 lineItem.PropertyBag = lineItem.PropertyBag ?? new Orckestra.Overture.ServiceModel.PropertyBag();
                 lineItem.ProductSummary.AllowSelectionWithoutScan = allowSelectionWithoutScan;
-
-                if (!string.IsNullOrWhiteSpace(imageUrl))
-                {
-                    lineItem.PropertyBag[ImageUrlKey] = imageUrl;
-                }
-                else
-                {
-                    context.ProcessingRecordTracker.TrackError(imageUrl ?? CultureNotFoundMessageId,
-                        "The cultureName of the cart was not provided in context.CurrentOrder.Cart.CultureName. Product information will not be retrieved.    " + imageUrl + "-----",
-                        new Dictionary<string, object> { { "CartId", context.CurrentOrder.Cart.Id } });
-
-                    lineItem.PropertyBag.Remove(ImageUrlKey);
-                }
 
                 AddPropertyBagForType(lineItem, product, nameof(Boolean), TestBoolean);
                 AddPropertyBagForType(lineItem, product, nameof(String), TestText);


### PR DESCRIPTION
I am not sure why this code was added here to override lineitem.ImageUrl, but we have **FetchLineItemInformationActivity** and it sets correct varaint.ImageUrl, but for some reason this additional activity overrides it and is always set to Base Product.ImageUrl

Without this code we have correct variant images in the Cart:

![image](https://user-images.githubusercontent.com/6649972/236175771-a20d86e1-1a3d-458f-80f5-4bba9930f080.png)



[AB#71514](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/71514)