### PR TITLE
Allow 256-char max for Product Display Name - BetterRetail

### DIFF
--- a/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/QueueProductCatalogsImportsActivity/Global-Schema-v1.0/schema.json
+++ b/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/QueueProductCatalogsImportsActivity/Global-Schema-v1.0/schema.json
@@ -515,7 +515,7 @@
       "isMultilingual": true,
       "dataType": "Text",
       "minimumValue": 0,
-      "maximumValue": 128,
+      "maximumValue": 256,
       "includeInAllProductDefinition": true,
       "includeInAllCategoryDefinition": true,
       "includeInAllVariantDefinition": true,


### PR DESCRIPTION
Once longer Product Display Name values are allowed elsewhere in our product suite, tthe Product import steps will fail in Release pipelines unless this increase is made in the CommerceModel.  