### PR TITLE
Features/79608 import service levels

### DIFF
--- a/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/CreateStoresActivity/BetterRetailUSA/BRU-101.json
+++ b/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/CreateStoresActivity/BetterRetailUSA/BRU-101.json
@@ -146,12 +146,12 @@
       "city": "New York",
       "countryCode": "US",
       "regionCode": "US-NY",
-      "line1": "113 Sullivan St",
-      "postalCode": "10012",
+      "line1": "4 Concord Ave",
+      "postalCode": "12901",
       "latitude": 40.725944,
       "longitude": -74.002635,
-      "isPreferredBilling": false,
-      "isPreferredShipping": false,
+      "isPreferredBilling": true,
+      "isPreferredShipping": true,
       "propertyBag": {
         "Address_Id": {
           "__type": "ValueOfInt32",

--- a/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/QueueOrderSchemaImportActivity/providers.json
+++ b/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/QueueOrderSchemaImportActivity/providers.json
@@ -478,13 +478,13 @@
   {
     "type": "Shipping",
     "scopeId": "BetterRetailCanada",
-    "name": "Ship from store (Load Balanced)",
+    "name": "SFS (Load Balanced, Shippo)",
     "implementationTypeName": "ShipFromStoreFulfillmentProvider",
     "description": "The Ship from Store Load Balanced Fulfillment Provider is designed to sequentially route order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order, or part of the order if more than one shipment per order is allowed. The priority phase then determines the next Fulfillment location to select for the shipment. The underlying Load Balanced Routing Provider controls splitting and prioritization. The provider then governs policies associated with in-store fulfillment, concluding with stores shipping the order shipments to the customer. Ship From Store fulfills orders using the fulfillment location’s own inventory.",
     "displayName": {
-      "en-US": "SFS Fulfillment Provider (Load Balanced)",
-      "en-CA": "SFS Fulfillment Provider (Load Balanced)",
-      "fr-CA": "Fournisseur SFS (Charge équilibrée)"
+      "en-US": "SFS (Load Balanced, Shippo)",
+      "en-CA": "SFS (Load Balanced, Shippo)",
+      "fr-CA": "SFS (Charge équilibrée, Shippo)"
     },
     "isActive": true,
     "values": {
@@ -528,13 +528,13 @@
   {
     "type": "Shipping",
     "scopeId": "BetterRetailCanada",
-    "name": "Ship from store Short (Load Balanced)",
+    "name": "SFS Short (Load Balanced, Canada Post)",
     "implementationTypeName": "ShipFromStoreShortFulfillmentProvider",
     "description": "The Ship from Store Short Fulfillment Provider is designed to route order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order, or part of the order if more than one shipment per order is allowed. The priority phase determines the next Fulfillment location to select for the order. It then governs policies associated with in-store fulfillment, concluding with the store shipping the order shipment to the customer. Ship From Store fulfills orders using the fulfillment location's own inventory.",
     "displayName": {
-      "en-US": "SFS Short Fulfillment Provider (Load Balanced)",
-      "en-CA": "SFS Short Fulfillment Provider (Load Balanced)",
-      "fr-CA": "Fournisseur SFS court (Charge équilibrée)"
+      "en-US": "SFS Short (Load Balanced, Canada Post)",
+      "en-CA": "SFS Short (Load Balanced, Canada Post)",
+      "fr-CA": "SFS court (Charge équilibrée, Poste Canada)"
     },
     "isActive": true,
     "values": {
@@ -682,13 +682,13 @@
   {
     "type": "Shipping",
     "scopeId": "BetterRetailCanada",
-    "name": "Ship from store (Competition)",
+    "name": "SFS (Competition, Shippo)",
     "implementationTypeName": "ShipFromStoreFulfillmentProvider",
     "description": "The Ship from Store Competition Fulfillment Provider is designed to offer order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order. The priority phase then offers the shipment to all eligible Fulfillment Locations in order to elicit a competition to seize it. The underlying Competition Routing Provider controls splitting and competition prioritization. The provider then governs policies associated with in-store fulfillment, concluding with the store shipping the order shipment to the customer. Ship From Store fulfills orders using the fulfillment location’s own inventory.",
     "displayName": {
-      "en-US": "SFS Fulfillment Provider (Competition)",
-      "en-CA": "SFS Fulfillment Provider (Competition)",
-      "fr-CA": "Fournisseur SFS (Compétition)"
+      "en-US": "SFS (Competition, Shippo)",
+      "en-CA": "SFS (Competition, Shippo)",
+      "fr-CA": "SFS (Compétition, Shippo)"
     },
     "isActive": false,
     "values": {
@@ -724,13 +724,13 @@
   {
     "type": "Shipping",
     "scopeId": "BetterRetailCanada",
-    "name": "Ship from store Short (Competition)",
+    "name": "SFS Short (Competition, Canada Post)",
     "implementationTypeName": "ShipFromStoreShortFulfillmentProvider",
     "description": "The Ship from Store Short Competition Fulfillment Provider is designed to offer order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order. The priority phase then offers the shipment to all eligible Fulfillment Locations in order to elicit a competition to seize it. The underlying Competition Routing Provider controls splitting and competition prioritization. The provider then governs policies associated with in-store fulfillment, concluding with the store shipping the order shipment to the customer. Ship From Store fulfills orders using the fulfillment location’s own inventory.",
     "displayName": {
-      "en-US": "SFS Short Fulfillment Provider (Competition)",
-      "en-CA": "SFS Short Fulfillment Provider (Competition)",
-      "fr-CA": "Fournisseur SFS court (Compétition)"
+      "en-US": "SFS Short (Competition, Canada Post)",
+      "en-CA": "SFS Short (Competition, Canada Post)",
+      "fr-CA": "SFS court (Compétition, Poste Canada)"
     },
     "isActive": false,
     "values": {
@@ -2348,12 +2348,12 @@
     "id": "2F036881-2E6C-4317-B343-60B8FE29A0C9",
     "type": "Shipping",
     "scopeId": "BetterRetailEuro",
-    "name": "Ship from store (Load Balanced)",
+    "name": "SFS (Load Balanced, Shippo)",
     "implementationTypeName": "ShipFromStoreFulfillmentProvider",
     "displayName": {
-      "en-US": "SFS Fulfillment Provider (Load Balanced)",
-      "en-CA": "SFS Fulfillment Provider (Load Balanced)",
-      "fr-CA": "Fournisseur SFS (Charge équilibrée)"
+      "en-US": "SFS (Load Balanced, Shippo)",
+      "en-CA": "SFS (Load Balanced, Shippo)",
+      "fr-CA": "SFS (Charge équilibrée, Shippo)"
     },
     "description": "The Ship from Store Fulfillment Provider is designed to route order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order, or part of the order if more than one shipment per order is allowed. The priority phase determines the next Fulfillment location to select for the order. It then governs policies associated with in-store fulfillment, concluding with the store shipping the order shipment to the customer. Ship From Store fulfills orders using the fulfillment location's own inventory.",
     "isActive": true,
@@ -2398,13 +2398,13 @@
   {
     "type": "Shipping",
     "scopeId": "BetterRetailEuro",
-    "name": "Ship from store Short (Load Balanced)",
+    "name": "SFS Short (Load Balanced, Canada Post)",
     "implementationTypeName": "ShipFromStoreShortFulfillmentProvider",
     "description": "The Ship from Store Short Fulfillment Provider is designed to route order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order, or part of the order if more than one shipment per order is allowed. The priority phase determines the next Fulfillment location to select for the order. It then governs policies associated with in-store fulfillment, concluding with the store shipping the order shipment to the customer. Ship From Store fulfills orders using the fulfillment location's own inventory.",
     "displayName": {
-      "en-US": "SFS Short Fulfillment Provider (Load Balanced)",
-      "en-CA": "SFS Short Fulfillment Provider (Load Balanced)",
-      "fr-CA": "Fournisseur SFS court (Charge équilibrée)"
+      "en-US": "SFS Short (Load Balanced, Canada post)",
+      "en-CA": "SFS Short (Load Balanced, Canada post)",
+      "fr-CA": "SFS court (Charge équilibrée, Poste Canada)"
     },
     "isActive": true,
     "values": {
@@ -2563,13 +2563,13 @@
     "id": "13DAC5EC-475E-4639-A152-9E695FB0AA2F",
     "type": "Shipping",
     "scopeId": "BetterRetailEuro",
-    "name": "Ship from store (Competition)",
+    "name": "SFS (Competition, Shippo)",
     "implementationTypeName": "ShipFromStoreFulfillmentProvider",
     "description": "The Ship from Store Competition Fulfillment Provider is designed to offer order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order. The priority phase then offers the shipment to all eligible Fulfillment Locations in order to elicit a competition to seize it. The underlying Competition Routing Provider controls splitting and competition prioritization. The provider then governs policies associated with in-store fulfillment, concluding with the store shipping the order shipment to the customer. Ship From Store fulfills orders using the fulfillment location's own inventory.",
     "displayName": {
-      "en-US": "SFS Fulfillment Provider (Competition)",
-      "en-CA": "SFS Fulfillment Provider (Competition)",
-      "fr-CA": "Fournisseur SFS (Compétition)"
+      "en-US": "SFS (Competition, Shippo)",
+      "en-CA": "SFS (Competition, Shippo)",
+      "fr-CA": "SFS (Compétition, Shippo)"
     },
     "isActive": true,
     "values": {
@@ -2613,13 +2613,13 @@
   {
     "type": "Shipping",
     "scopeId": "BetterRetailEuro",
-    "name": "Ship from store Short (Competition)",
+    "name": "SFS Short (Competition, Canada Post)",
     "implementationTypeName": "ShipFromStoreShortFulfillmentProvider",
     "description": "The Ship from Store Short Competition Fulfillment Provider is designed to offer order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order. The priority phase then offers the shipment to all eligible Fulfillment Locations in order to elicit a competition to seize it. The underlying Competition Routing Provider controls splitting and competition prioritization. The provider then governs policies associated with in-store fulfillment, concluding with the store shipping the order shipment to the customer. Ship From Store fulfills orders using the fulfillment location’s own inventory.",
     "displayName": {
-      "en-US": "SFS Short Fulfillment Provider (Competition)",
-      "en-CA": "SFS Short Fulfillment Provider (Competition)",
-      "fr-CA": "Fournisseur SFS court (Compétition)"
+      "en-US": "SFS Short (Competition, Canada Post)",
+      "en-CA": "SFS Short (Competition, Canada Post)",
+      "fr-CA": "SFS court (Compétition, Poste Canada)"
     },
     "isActive": true,
     "values": {
@@ -3160,13 +3160,13 @@
   {
     "type": "Shipping",
     "scopeId": "BetterRetailUSA",
-    "name": "Ship from store (Load Balanced)",
+    "name": "SFS (Load Balanced, Shippo)",
     "implementationTypeName": "ShipFromStoreFulfillmentProvider",
     "description": "The Ship from Store Load Balanced Fulfillment Provider is designed to sequentially route order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order, or part of the order if more than one shipment per order is allowed. The priority phase then determines the next Fulfillment location to select for the shipment. The underlying Load Balanced Routing Provider controls splitting and prioritization. The provider then governs policies associated with in-store fulfillment, concluding with stores shipping the order shipments to the customer. Ship From Store fulfills orders using the fulfillment location’s own inventory.",
     "displayName": {
-      "en-US": "SFS Fulfillment Provider (Load Balanced)",
-      "en-CA": "SFS Fulfillment Provider (Load Balanced)",
-      "fr-CA": "Fournisseur SFS (Charge équilibrée)"
+      "en-US": "SFS (Load Balanced, Shippo)",
+      "en-CA": "SFS (Load Balanced, Shippo)",
+      "fr-CA": "SFS (Charge équilibrée, Shippo)"
     },
     "isActive": true,
     "values": {
@@ -3210,13 +3210,13 @@
   {
     "type": "Shipping",
     "scopeId": "BetterRetailUSA",
-    "name": "Ship from store Short (Load Balanced)",
+    "name": "SFS Short (Load Balanced, Canada Post)",
     "implementationTypeName": "ShipFromStoreShortFulfillmentProvider",
     "description": "The Ship from Store Short Fulfillment Provider is designed to route order shipments, to ship to customers, to one of many fulfillment locations and to offer them for fulfillment. Routing is performed in two phases. The eligibility phase elects a group of fulfillment locations able to fulfill the order, or part of the order if more than one shipment per order is allowed. The priority phase determines the next Fulfillment location to select for the order. It then governs policies associated with in-store fulfillment, concluding with the store shipping the order shipment to the customer. Ship From Store fulfills orders using the fulfillment location's own inventory.",
     "displayName": {
-      "en-US": "SFS Short Fulfillment Provider (Load Balanced)",
-      "en-CA": "SFS Short Fulfillment Provider (Load Balanced)",
-      "fr-CA": "Fournisseur SFS court (Charge équilibrée)"
+      "en-US": "SFS Short (Load Balanced, Canada Post)",
+      "en-CA": "SFS Short (Load Balanced, Canada Post)",
+      "fr-CA": "SFS court (Charge équilibrée, Poste Canada)"
     },
     "isActive": true,
     "values": {
@@ -3506,12 +3506,12 @@
     "id": "f1b78649331b4ea7a5fb1c38f9bcb159",
     "type": "Shipping",
     "scopeId": "BetterRetailCanada",
-    "name": "SFS (Multi Segment)",
+    "name": "SFS (Multi Segment, Shippo)",
     "implementationTypeName": "ShipFromStoreFulfillmentProvider",
     "displayName": {
-      "en-US": "SFS (Multi Segment)",
-      "en-CA": "SFS (Multi Segment)",
-      "fr-CA": "SFS (Multi Segment)"
+      "en-US": "SFS (Multi Segment, Shippo)",
+      "en-CA": "SFS (Multi Segment, Shippo)",
+      "fr-CA": "SFS (Multi Segment, Shippo)"
     },
     "isActive": false,
     "values": {
@@ -3613,12 +3613,12 @@
     "id": "020f55e6a7d246b392b46271c1e6fe9d",
     "type": "Shipping",
     "scopeId": "BetterRetailCanada",
-    "name": "SFS (Shortest Distance)",
+    "name": "SFS (Shortest Distance, Shippo)",
     "implementationTypeName": "ShipFromStoreFulfillmentProvider",
     "displayName": {
-      "en-US": "SFS (Shortest Distance)",
-      "en-CA": "SFS (Shortest Distance)",
-      "fr-CA": "SFS (Shortest Distance)"
+      "en-US": "SFS (Shortest Distance, Shippo)",
+      "en-CA": "SFS (Shortest Distance, Shippo)",
+      "fr-CA": "SFS (Shortest Distance, Shippo)"
     },
     "isActive": false,
     "values": {
@@ -3668,12 +3668,12 @@
     "id": "b0257d21aef943ae8444a7a57244db63",
     "type": "Shipping",
     "scopeId": "BetterRetailCanada",
-    "name": "SFS Short (Multi Segment)",
+    "name": "SFS Short (Multi Segment, Canada Post)",
     "implementationTypeName": "ShipFromStoreShortFulfillmentProvider",
     "displayName": {
-      "en-US": "SFS Short (Multi Segment)",
-      "en-CA": "SFS Short (Multi Segment)",
-      "fr-CA": "SFS Short (Multi Segment)"
+      "en-US": "SFS Short (Multi Segment, Canada Post)",
+      "en-CA": "SFS Short (Multi Segment, Canada Post)",
+      "fr-CA": "SFS Short (Multi Segment, Poste Canada)"
     },
     "isActive": true,
     "values": {
@@ -3727,12 +3727,12 @@
     "id": "7420fd9df7114006ad50ea565c6fb6f1",
     "type": "Shipping",
     "scopeId": "BetterRetailCanada",
-    "name": "SFS Short (Shortest Distance)",
+    "name": "SFS Short (Shortest Distance, Canada Post)",
     "implementationTypeName": "ShipFromStoreShortFulfillmentProvider",
     "displayName": {
-      "en-US": "SFS Short (Shortest Distance)",
-      "en-CA": "SFS Short (Shortest Distance)",
-      "fr-CA": "SFS Short (Shortest Distance)"
+      "en-US": "SFS Short (Shortest Distance, Canada Post)",
+      "en-CA": "SFS Short (Shortest Distance, Canada Post)",
+      "fr-CA": "SFS Short (Shortest Distance, Poste Canada)"
     },
     "isActive": true,
     "values": {

--- a/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/QueueOrderSchemaImportActivity/providers.json
+++ b/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/QueueOrderSchemaImportActivity/providers.json
@@ -489,6 +489,7 @@
     "isActive": true,
     "values": {
       "FulfillmentRoutingProviderId": "7957A7F8-E628-4613-979C-F65FCF59AD4D",
+      "FulfillmentCarrierProviderId": "873ED561-3FD3-4DFA-9FAE-CFECDDCB2CCD",
       "AcceptanceSLAInMinutes": {
         "__type": "ValueOfInt32",
         "value": 60
@@ -538,6 +539,7 @@
     "isActive": true,
     "values": {
       "FulfillmentRoutingProviderId": "7957A7F8-E628-4613-979C-F65FCF59AD4D",
+      "FulfillmentCarrierProviderId": "D168E411-ABDC-42C0-A9A9-A5D97E28847D",
       "AcceptanceSLAInMinutes": {
         "__type": "ValueOfInt32",
         "value": 60
@@ -575,6 +577,106 @@
         "value": 1
       }
     },
+    "fulfillmentServiceLevels": [
+      {
+        "id": "c9a9e78ac6164c2daf7234595bf29221",
+        "code": "Regular",
+        "description": "Regular service level",
+        "displayName": {
+          "en-US": "Regular service",
+          "en-CA": "Regular serivce",
+          "fr-CA": "Service régulier"
+        },
+        "isActive": true,
+        "implementationTypeName": "PreferredCarrierFulfillmentServiceLevel",
+        "fulfillmentCarrierServices": [
+          {
+            "Id": "037b05c0b6e74becb58ce5f55d3f4a90",
+            "Name": "Canada Post",
+            "CarrierName": "Canada Post",
+            "CarrierServiceLevel": "canada_post_regular_parcel",
+            "implementationTypeName": "DefaultFulfillmentCarrierService"
+          },
+          {
+            "Id": "037b05c0b6e74becb58ce5f55d3f4a91",
+            "Name": "Purolator",
+            "CarrierName": "Purolator",
+            "CarrierServiceLevel": "purolator_ground",
+            "implementationTypeName": "DefaultFulfillmentCarrierService"
+          },
+          {
+            "Id": "037b05c0b6e74becb58ce5f55d3f4a92",
+            "Name": "UPS",
+            "CarrierName": "UPS",
+            "CarrierServiceLevel": "ups_standard",
+            "implementationTypeName": "DefaultFulfillmentCarrierService"
+          }
+        ]
+      },
+      {
+        "id": "c9a9e78ac6164c2daf7234595bf29222",
+        "code": "Express",
+        "description": "Express service level",
+        "displayName": {
+          "en-US": "Express service",
+          "en-CA": "Express serivce",
+          "fr-CA": "Service express"
+        },
+        "isActive": true,
+        "implementationTypeName": "PreferredCarrierFulfillmentServiceLevel",
+        "fulfillmentCarrierServices": [
+          {
+            "Id": "037b05c0b6e74becb58ce5f55d3f4a93",
+            "Name": "Canada Post Expedited",
+            "CarrierName": "Canada Post",
+            "CarrierServiceLevel": "canada_post_expedited_parcel",
+            "implementationTypeName": "DefaultFulfillmentCarrierService"
+          },
+          {
+            "Id": "037b05c0b6e74becb58ce5f55d3f4a94",
+            "Name": "Canada Post Xpresspost",
+            "CarrierName": "Canada Post",
+            "CarrierServiceLevel": "canada_post_xpresspost",
+            "implementationTypeName": "DefaultFulfillmentCarrierService"
+          },
+          {
+            "Id": "037b05c0b6e74becb58ce5f55d3f4a95",
+            "Name": "Purolator",
+            "CarrierName": "Purolator",
+            "CarrierServiceLevel": "purolator_express",
+            "implementationTypeName": "DefaultFulfillmentCarrierService"
+          },
+          {
+            "Id": "037b05c0b6e74becb58ce5f55d3f4a96",
+            "Name": "UPS",
+            "CarrierName": "UPS",
+            "CarrierServiceLevel": "ups_express",
+            "implementationTypeName": "DefaultFulfillmentCarrierService"
+          }
+        ]
+      },
+      {
+        "id": "c9a9e78ac6164c2daf7234595bf29223",
+        "code": "Same-day",
+        "description": "Same-day service level",
+        "displayName": {
+          "en-US": "Same-day",
+          "en-CA": "Same-day",
+          "fr-CA": "Le jour même"
+        },
+        "isActive": true,
+        "implementationTypeName": "PreferredCarrierFulfillmentServiceLevel",
+        "fulfillmentCarrierServices": [
+          {
+            "Id": "037b05c0b6e74becb58ce5f55d3f4a97",
+            "Name": "DoorDash",
+            "CarrierName": "DoorDash",
+            "CarrierServiceLevel": "delivery",
+            "implementationTypeName": "DefaultFulfillmentCarrierService"
+          }
+        ]
+      }
+    ],
     "propertyConfigurations": {}
   },
   {
@@ -588,9 +690,10 @@
       "en-CA": "SFS Fulfillment Provider (Competition)",
       "fr-CA": "Fournisseur SFS (Compétition)"
     },
-    "isActive": true,
+    "isActive": false,
     "values": {
       "FulfillmentRoutingProviderId": "7A169585-DA71-442D-8F74-02BEAFB03B3C",
+      "FulfillmentCarrierProviderId": "873ED561-3FD3-4DFA-9FAE-CFECDDCB2CCD",
       "AcceptanceSLAInMinutes": {
         "__type": "ValueOfInt32",
         "value": 60
@@ -629,9 +732,10 @@
       "en-CA": "SFS Short Fulfillment Provider (Competition)",
       "fr-CA": "Fournisseur SFS court (Compétition)"
     },
-    "isActive": true,
+    "isActive": false,
     "values": {
       "FulfillmentRoutingProviderId": "7A169585-DA71-442D-8F74-02BEAFB03B3C",
+      "FulfillmentCarrierProviderId": "D168E411-ABDC-42C0-A9A9-A5D97E28847D",
       "AcceptanceSLAInMinutes": {
         "__type": "ValueOfInt32",
         "value": 60
@@ -671,7 +775,7 @@
     "displayName": {
 
     },
-    "isActive": true,
+    "isActive": false,
     "values": {
       "Cost": {
         "__type": "ValueOfDouble",
@@ -692,7 +796,7 @@
     "displayName": {
 
     },
-    "isActive": true,
+    "isActive": false,
     "values": {
       "Cost": {
         "__type": "ValueOfDouble",
@@ -3409,7 +3513,7 @@
       "en-CA": "SFS (Multi Segment)",
       "fr-CA": "SFS (Multi Segment)"
     },
-    "isActive": true,
+    "isActive": false,
     "values": {
       "ForceManualCarrierSelection": {
         "__type": "ValueOfBoolean",
@@ -3439,7 +3543,8 @@
         "__type": "ValueOfInt32",
         "value": 60
       },
-      "FulfillmentRoutingProviderId": "521e1f1c0d0f49bfa6134d4f1f8d38db",
+      "FulfillmentRoutingProviderId": "521E1F1C-0D0F-49BF-A613-4D4F1F8D38DB",
+      "FulfillmentCarrierProviderId": "873ED561-3FD3-4DFA-9FAE-CFECDDCB2CCD",
       "OrderSplitOnItemsAndUnitsAllowed": {
         "__type": "ValueOfBoolean",
         "value": false
@@ -3515,7 +3620,7 @@
       "en-CA": "SFS (Shortest Distance)",
       "fr-CA": "SFS (Shortest Distance)"
     },
-    "isActive": true,
+    "isActive": false,
     "values": {
       "ForceManualCarrierSelection": {
         "__type": "ValueOfBoolean",
@@ -3545,7 +3650,8 @@
         "__type": "ValueOfInt32",
         "value": 60
       },
-      "FulfillmentRoutingProviderId": "a45dc1d7a7a84134b336549138a285c5",
+      "FulfillmentRoutingProviderId": "A45DC1D7-A7A8-4134-B336-549138A285C5",
+      "FulfillmentCarrierProviderId": "873ED561-3FD3-4DFA-9FAE-CFECDDCB2CCD",
       "OrderSplitOnItemsAndUnitsAllowed": {
         "__type": "ValueOfBoolean",
         "value": false
@@ -3603,7 +3709,8 @@
         "__type": "ValueOfInt32",
         "value": 60
       },
-      "FulfillmentRoutingProviderId": "521e1f1c0d0f49bfa6134d4f1f8d38db",
+      "FulfillmentRoutingProviderId": "521E1F1C-0D0F-49BF-A613-4D4F1F8D38DB",
+      "FulfillmentCarrierProviderId": "D168E411-ABDC-42C0-A9A9-A5D97E28847D",
       "OrderSplitOnItemsAndUnitsAllowed": {
         "__type": "ValueOfBoolean",
         "value": false
@@ -3662,6 +3769,7 @@
         "value": 60
       },
       "FulfillmentRoutingProviderId": "a45dc1d7a7a84134b336549138a285c5",
+      "FulfillmentCarrierProviderId": "D168E411-ABDC-42C0-A9A9-A5D97E28847D",
       "OrderSplitOnItemsAndUnitsAllowed": {
         "__type": "ValueOfBoolean",
         "value": false
@@ -3781,7 +3889,7 @@
         "value": 30
       },
       "DefaultReturnCountry": "ca",
-      "FulfillmentCarrierProviderId": "d168e411abdc42c0a9a9a5d97e28847d",
+      "FulfillmentCarrierProviderId": "D168E411-ABDC-42C0-A9A9-A5D97E28847D",
       "DefaultReturnZipPostalCode": "J4K5G4",
       "GenerateOrderReturnLabels": {
         "__type": "ValueOfBoolean",

--- a/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/QueueProfilesImportActivity/ADDRESS.json
+++ b/src/CommerceModel.BetterRetail/artifacts/OOE/BetterRetail/QueueProfilesImportActivity/ADDRESS.json
@@ -8,7 +8,7 @@
     "True",
     "US",
     "CommerceModel.BetterRetail",
-    "10014",
+    "12901",
     "2022-01-01T00:00:00.0000000",
     "True",
     "7a3e1e55-9b0a-4d44-b95c-af5235c51b4d",
@@ -16,7 +16,7 @@
     "2022-01-01T00:00:00.0000000",
     "New York",
     "CommerceModel.BetterRetail",
-    "38 King St"
+    "24 W Court St"
   ],
   [
     "CA-QC",


### PR DESCRIPTION
Main changes in CommerceModel:
1. Added ServiceLevels to SFS Short Fulfillment Provider (Load Balanced)
2. Added FulfillmentCarrierProviderId to fulfillment providers
3. Updated US addresses to allow using DeliverySolutions without needing to update addresses manually

Feature: [AB#79608](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/79608)